### PR TITLE
fix invalid face for markdown-table-font

### DIFF
--- a/adaptive-wrap.el
+++ b/adaptive-wrap.el
@@ -60,11 +60,12 @@ extra indent = 2
 (make-variable-buffer-local 'adaptive-wrap-extra-indent)
 
 (defun adaptive-wrap--face-extends (face)
-  (if (fboundp 'face-extend-p)
-      (face-extend-p face nil t)
-    ;; Before Emacs 27, faces always extended beyond EOL.  Check for a
-    ;; non-default background.
-    (face-background face nil t)))
+  (let ((f (if (atom face) face (first face))))
+    (if (fboundp 'face-extend-p)
+        (face-extend-p f nil t)
+      ;; Before Emacs 27, faces always extended beyond EOL.  Check for a
+      ;; non-default background.
+      (face-background f nil t))))
 
 (defun adaptive-wrap--prefix-face (fcp beg end)
   (cond ((get-text-property 0 'face fcp))


### PR DESCRIPTION
Emacs 27.1
    https://github.com/railwaycat/homebrew-emacsmacport/commit/6575b3a9100dad480f1f8c0a421aeb6d401dfc05
    https://github.com/jrblevin/markdown-mode/commit/dcad5572a30fce51b97963d3c869cce227c223a1

Fixed https://github.com/casouri/valign/issues/19